### PR TITLE
Upgrade .NET SDK/runtime

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "5.0.x"
+          dotnet-version: "6.0.x"
       - run: |
           dotnet tool install -g dotnet-format
           echo "$HOME/.dotnet/tools" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Run dotnet format
         working-directory: ${{env.working-directory}}
         run: |
-          dotnet format --check platform-gateway.sln
+          dotnet format --verify-no-changes platform-gateway.sln

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 05-12-2021
+### Updated 
+- .NET SDK/runtime
+- Project dependencies
+
 ## [1.2.0] - 07-08-2021
 ### Updated 
 - Update the router package

--- a/SensateIoT.Platform.Network.Common/SensateIoT.Platform.Network.Common.csproj
+++ b/SensateIoT.Platform.Network.Common/SensateIoT.Platform.Network.Common.csproj
@@ -15,15 +15,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="MQTTnet" Version="3.0.16" />
+    <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="MQTTnet" Version="3.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="prometheus-net" Version="4.2.0" />
-    <PackageReference Include="prometheus-net.AspNetCore" Version="4.2.0" />
-    <PackageReference Include="SensateIoT.Platform.Router.Contracts" Version="1.4.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.2.62" />
+    <PackageReference Include="prometheus-net" Version="5.0.2" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="5.0.2" />
+    <PackageReference Include="SensateIoT.Platform.Router.Contracts" Version="1.4.1" />
+    <PackageReference Include="StackExchange.Redis" Version="2.2.88" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SensateIoT.Platform.Network.Data/SensateIoT.Platform.Network.Data.csproj
+++ b/SensateIoT.Platform.Network.Data/SensateIoT.Platform.Network.Data.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Bson" Version="2.13.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.13.1" />
+    <PackageReference Include="MongoDB.Bson" Version="2.14.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.14.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="SendGrid" Version="9.24.1" />
+    <PackageReference Include="SendGrid" Version="9.25.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/SensateIoT.Platform.Network.Data/SensateIoT.Platform.Network.Data.csproj
+++ b/SensateIoT.Platform.Network.Data/SensateIoT.Platform.Network.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>0.0.0</Version>
   </PropertyGroup>
 

--- a/SensateIoT.Platform.Network.DataAccess/SensateIoT.Platform.Network.DataAccess.csproj
+++ b/SensateIoT.Platform.Network.DataAccess/SensateIoT.Platform.Network.DataAccess.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.13.1" />
-    <PackageReference Include="Npgsql" Version="5.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.14.1" />
+    <PackageReference Include="Npgsql" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SensateIoT.Platform.Network.GatewayAPI/Dockerfile
+++ b/SensateIoT.Platform.Network.GatewayAPI/Dockerfile
@@ -5,7 +5,7 @@
 # @email  michel@michelmegens.net
 #
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 
 WORKDIR /build
 
@@ -13,7 +13,7 @@ COPY . .
 RUN dotnet restore -r linux-x64 SensateIoT.Platform.Network.GatewayAPI/SensateIoT.Platform.Network.GatewayAPI.csproj
 RUN dotnet publish -c Release -o /build/binaries -r linux-x64 --no-restore SensateIoT.Platform.Network.GatewayAPI/SensateIoT.Platform.Network.GatewayAPI.csproj
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 
 COPY --from=build-env /build/binaries /app
 COPY SensateIoT.Platform.Network.GatewayAPI/appsettings.json /app/appsettings.json

--- a/SensateIoT.Platform.Network.GatewayAPI/SensateIoT.Platform.Network.GatewayAPI.csproj
+++ b/SensateIoT.Platform.Network.GatewayAPI/SensateIoT.Platform.Network.GatewayAPI.csproj
@@ -19,11 +19,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SensateIoT.Platform.Network.GatewayAPI/SensateIoT.Platform.Network.GatewayAPI.csproj
+++ b/SensateIoT.Platform.Network.GatewayAPI/SensateIoT.Platform.Network.GatewayAPI.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <Version>1.2.0</Version>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <Version>1.2.1</Version>
+    <AssemblyVersion>1.2.1.0</AssemblyVersion>
+    <FileVersion>1.2.1.0</FileVersion>
     <Company>Sensate IoT</Company>
     <Product>Sensate IoT Gateway</Product>
     <Authors>Sensate IoT</Authors>


### PR DESCRIPTION
Upgrade the .NET runtime version from .NET 5 to .NET 6.

## Description
The Platform Gateway service now targets the .NET 6 runtime, instead of .NET 5. The unit test project has also been updated in order to target this version of the .NET environment.

## Motivation and Context
Migrate away from older versions of .NET.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.